### PR TITLE
Export latest deprecated field

### DIFF
--- a/Commands/self-help/discovery-solution/_list.md
+++ b/Commands/self-help/discovery-solution/_list.md
@@ -1,6 +1,6 @@
 # [Command] _self-help discovery-solution list_
 
-List the relevant Azure diagnostics and solutions using problemClassificationId API AND resourceUri or resourceType.
+List the relevant Azure diagnostics and solutions using problemClassificationId
 
 ## Versions
 
@@ -34,5 +34,5 @@ List the relevant Azure diagnostics and solutions using problemClassificationId 
 
 - Discover Solutions
     ```bash
-        self-help discovery-solution list --filter "ProblemClassificationId eq '00000000-0000-0000-0000-000000000000'" --scope 'subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourceGroup/providers/Microsoft.KeyVault/vaults/test-keyvault-non-read'
+        self-help discovery-solution list --filter "ProblemClassificationId eq '00000000-0000-0000-0000-000000000000'"
     ```

--- a/Commands/self-help/discovery-solution/readme.md
+++ b/Commands/self-help/discovery-solution/readme.md
@@ -5,10 +5,10 @@ discovery-solution command will help you discover available solutions based on y
 ## Commands
 
 - [list](/Commands/self-help/discovery-solution/_list.md)
-: List the relevant Azure diagnostics and solutions using problemClassificationId API AND resourceUri or resourceType.
+  : List the relevant Azure diagnostics and solutions using problemClassificationId
 
 - [list-nlp](/Commands/self-help/discovery-solution/_list-nlp.md)
-: Search for relevant Azure Diagnostics, Solutions and Troubleshooters using a natural language issue summary.
+  : Search for relevant Azure Diagnostics, Solutions and Troubleshooters using a natural language issue summary.
 
 - [list-nlp-subscription](/Commands/self-help/discovery-solution/_list-nlp-subscription.md)
-: Search for relevant Azure Diagnostics, Solutions and Troubleshooters using a natural language issue summary and subscription.
+  : Search for relevant Azure Diagnostics, Solutions and Troubleshooters using a natural language issue summary and subscription.

--- a/Commands/self-help/solution-self-help/readme.md
+++ b/Commands/self-help/solution-self-help/readme.md
@@ -1,6 +1,6 @@
 # [Group] _self-help solution-self-help_
 
-solution command will help you get self help solutions for azure resources.
+Get Self Help Solutions for a given solutionId. Self Help Solutions consist of rich instructional video tutorials, links and guides to public documentation related to a specific problem that enables users to troubleshoot Azure issues.
 
 ## Commands
 


### PR DESCRIPTION
We are deprecating the "scope" field for "az self-help discovery-solution list" command. We were previously advised to add a deprecation message for that parameter and remove the parameter altogether during the breaking change window. The PRs involved here take care of removing the parameters, while the previous PRs that are already merged have included the warning message regarding upcoming deprecation in version 0.4.0.

CLI-Extensions repo PR:
https://github.com/Azure/azure-cli-extensions/pull/7619