### PR TITLE
chore: refine ci and hooks

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,11 +1,11 @@
 #!/usr/bin/env sh
-":" //; if command -v pwsh >/dev/null 2>&1; then pwsh -ExecutionPolicy Bypass -File .githooks/pre-push.ps1; else sh .githooks/pre-push.sh; fi; exit $?     # Try PowerShell Core first, then sh on Unix
+":" //; if command -v pwsh >/dev/null 2>&1; then pwsh -ExecutionPolicy Bypass -File .githooks/pre-commit.ps1; else sh .githooks/pre-commit.sh; fi; exit $?     # Try PowerShell Core first, then sh on Unix
 ":" //; exit                         # Skip rest on Unix
 
 @echo off
 powershell -NoProfile -Command "if (Get-Command powershell -ErrorAction SilentlyContinue) { exit 0 } else { exit 1 }"
 if %errorlevel% equ 0 (
-    powershell -ExecutionPolicy Bypass -File .githooks\pre-push.ps1
+    powershell -ExecutionPolicy Bypass -File .githooks\pre-commit.ps1
 ) else (
     echo Error: PowerShell is not available. Please install PowerShell.
     exit /b 1

--- a/.githooks/pre-commit.ps1
+++ b/.githooks/pre-commit.ps1
@@ -10,7 +10,7 @@ $Modules = $ChangedFiles |
     ForEach-Object { ($_ -split "/")[0] } |  # Extract the moudule
     Sort-Object -Unique  # Ensure uniqueness
 
-Write-Host "Verifying command models..." -ForegroundColor Green
+Write-Host "Verifying command models...`n" -ForegroundColor Green
 
 # Get Git root directory
 $GitRoot = git rev-parse --show-toplevel
@@ -20,7 +20,6 @@ $Modules | ForEach-Object {
     Write-Host "Running: aaz-dev command-model verify -a $GitRoot -t $_" -ForegroundColor Yellow # For logging
     aaz-dev command-model verify -a $GitRoot -t $_
     if ($LASTEXITCODE -ne 0) {
-        Write-Host "Please pull the latest <Main> branch, and <Export> your command model again." -ForegroundColor Red
         exit 1
     }
 }

--- a/.githooks/pre-commit.sh
+++ b/.githooks/pre-commit.sh
@@ -16,7 +16,7 @@ Modules=$(echo "$ChangedFiles" |
     cut -d '/' -f 1 |  # Extract the module
     sort -u)  # Ensure uniqueness
 
-echo "${GREEN}Verifying command models...${NC}"
+echo -e "${GREEN}Verifying command models...${NC}\n"
 
 # Get Git root directory
 GitRoot=$(git rev-parse --show-toplevel)
@@ -26,7 +26,6 @@ for Module in $Modules; do
     echo "${YELLOW}Running: aaz-dev command-model verify -a $GitRoot -t $Module${NC}" # For logging
     aaz-dev command-model verify -a "$GitRoot" -t "$Module"
     if [[ $? -ne 0 ]]; then
-        echo "${RED}Please pull the latest <Main> branch, and <Export> your command model again.${NC}"
         exit 1
     fi
 done

--- a/.github/workflows/verify-metadata.yml
+++ b/.github/workflows/verify-metadata.yml
@@ -28,10 +28,3 @@ jobs:
     - name: Verify data consistency
       id: verification
       run: aaz-dev command-model verify --aaz-path $GITHUB_WORKSPACE
-      continue-on-error: true
-
-    - name: Check on exception
-      if: steps.verification.outcome != 'success'
-      run: |
-        echo "Please pull the latest <main> branch, and <Export> your command model again."
-        exit 1


### PR DESCRIPTION
in ci, directly throw the exception.

in terminal, set the hooks at the pre-commit level, so that more inconsistencies can be detected earlier.