### PR TITLE
Promote computelimit commands from preview to stable

### DIFF
--- a/Commands/computelimit/guest-subscription/_add.md
+++ b/Commands/computelimit/guest-subscription/_add.md
@@ -4,7 +4,7 @@ Add a subscription as a guest to consume the compute limits shared by the host s
 
 ## Versions
 
-### [2025-08-15](/Resources/mgmt-plane/L3N1YnNjcmlwdGlvbnMve30vcHJvdmlkZXJzL21pY3Jvc29mdC5jb21wdXRlbGltaXQvbG9jYXRpb25zL3t9L2d1ZXN0c3Vic2NyaXB0aW9ucy97fQ==/2025-08-15.xml) **Preview**
+### [2025-08-15](/Resources/mgmt-plane/L3N1YnNjcmlwdGlvbnMve30vcHJvdmlkZXJzL21pY3Jvc29mdC5jb21wdXRlbGltaXQvbG9jYXRpb25zL3t9L2d1ZXN0c3Vic2NyaXB0aW9ucy97fQ==/2025-08-15.xml) **Stable**
 
 <!-- mgmt-plane /subscriptions/{}/providers/microsoft.computelimit/locations/{}/guestsubscriptions/{} 2025-08-15 -->
 

--- a/Commands/computelimit/guest-subscription/_list.md
+++ b/Commands/computelimit/guest-subscription/_list.md
@@ -4,7 +4,7 @@ List all guest subscriptions added to the host subscription in a location.
 
 ## Versions
 
-### [2025-08-15](/Resources/mgmt-plane/L3N1YnNjcmlwdGlvbnMve30vcHJvdmlkZXJzL21pY3Jvc29mdC5jb21wdXRlbGltaXQvbG9jYXRpb25zL3t9L2d1ZXN0c3Vic2NyaXB0aW9ucw==/2025-08-15.xml) **Preview**
+### [2025-08-15](/Resources/mgmt-plane/L3N1YnNjcmlwdGlvbnMve30vcHJvdmlkZXJzL21pY3Jvc29mdC5jb21wdXRlbGltaXQvbG9jYXRpb25zL3t9L2d1ZXN0c3Vic2NyaXB0aW9ucw==/2025-08-15.xml) **Stable**
 
 <!-- mgmt-plane /subscriptions/{}/providers/microsoft.computelimit/locations/{}/guestsubscriptions 2025-08-15 -->
 

--- a/Commands/computelimit/guest-subscription/_remove.md
+++ b/Commands/computelimit/guest-subscription/_remove.md
@@ -4,7 +4,7 @@ Remove a subscription as a guest to stop consuming the compute limits shared by 
 
 ## Versions
 
-### [2025-08-15](/Resources/mgmt-plane/L3N1YnNjcmlwdGlvbnMve30vcHJvdmlkZXJzL21pY3Jvc29mdC5jb21wdXRlbGltaXQvbG9jYXRpb25zL3t9L2d1ZXN0c3Vic2NyaXB0aW9ucy97fQ==/2025-08-15.xml) **Preview**
+### [2025-08-15](/Resources/mgmt-plane/L3N1YnNjcmlwdGlvbnMve30vcHJvdmlkZXJzL21pY3Jvc29mdC5jb21wdXRlbGltaXQvbG9jYXRpb25zL3t9L2d1ZXN0c3Vic2NyaXB0aW9ucy97fQ==/2025-08-15.xml) **Stable**
 
 <!-- mgmt-plane /subscriptions/{}/providers/microsoft.computelimit/locations/{}/guestsubscriptions/{} 2025-08-15 -->
 

--- a/Commands/computelimit/guest-subscription/_show.md
+++ b/Commands/computelimit/guest-subscription/_show.md
@@ -4,7 +4,7 @@ Get a guest subscription added to the host subscription
 
 ## Versions
 
-### [2025-08-15](/Resources/mgmt-plane/L3N1YnNjcmlwdGlvbnMve30vcHJvdmlkZXJzL21pY3Jvc29mdC5jb21wdXRlbGltaXQvbG9jYXRpb25zL3t9L2d1ZXN0c3Vic2NyaXB0aW9ucy97fQ==/2025-08-15.xml) **Preview**
+### [2025-08-15](/Resources/mgmt-plane/L3N1YnNjcmlwdGlvbnMve30vcHJvdmlkZXJzL21pY3Jvc29mdC5jb21wdXRlbGltaXQvbG9jYXRpb25zL3t9L2d1ZXN0c3Vic2NyaXB0aW9ucy97fQ==/2025-08-15.xml) **Stable**
 
 <!-- mgmt-plane /subscriptions/{}/providers/microsoft.computelimit/locations/{}/guestsubscriptions/{} 2025-08-15 -->
 

--- a/Commands/computelimit/shared-limit/_add.md
+++ b/Commands/computelimit/shared-limit/_add.md
@@ -4,7 +4,7 @@ Enable a compute limit to be shared by the host subscription with its guest subs
 
 ## Versions
 
-### [2025-08-15](/Resources/mgmt-plane/L3N1YnNjcmlwdGlvbnMve30vcHJvdmlkZXJzL21pY3Jvc29mdC5jb21wdXRlbGltaXQvbG9jYXRpb25zL3t9L3NoYXJlZGxpbWl0cy97fQ==/2025-08-15.xml) **Preview**
+### [2025-08-15](/Resources/mgmt-plane/L3N1YnNjcmlwdGlvbnMve30vcHJvdmlkZXJzL21pY3Jvc29mdC5jb21wdXRlbGltaXQvbG9jYXRpb25zL3t9L3NoYXJlZGxpbWl0cy97fQ==/2025-08-15.xml) **Stable**
 
 <!-- mgmt-plane /subscriptions/{}/providers/microsoft.computelimit/locations/{}/sharedlimits/{} 2025-08-15 -->
 

--- a/Commands/computelimit/shared-limit/_list.md
+++ b/Commands/computelimit/shared-limit/_list.md
@@ -4,7 +4,7 @@ List all compute limits shared by the host subscription with its guest subscript
 
 ## Versions
 
-### [2025-08-15](/Resources/mgmt-plane/L3N1YnNjcmlwdGlvbnMve30vcHJvdmlkZXJzL21pY3Jvc29mdC5jb21wdXRlbGltaXQvbG9jYXRpb25zL3t9L3NoYXJlZGxpbWl0cw==/2025-08-15.xml) **Preview**
+### [2025-08-15](/Resources/mgmt-plane/L3N1YnNjcmlwdGlvbnMve30vcHJvdmlkZXJzL21pY3Jvc29mdC5jb21wdXRlbGltaXQvbG9jYXRpb25zL3t9L3NoYXJlZGxpbWl0cw==/2025-08-15.xml) **Stable**
 
 <!-- mgmt-plane /subscriptions/{}/providers/microsoft.computelimit/locations/{}/sharedlimits 2025-08-15 -->
 

--- a/Commands/computelimit/shared-limit/_remove.md
+++ b/Commands/computelimit/shared-limit/_remove.md
@@ -4,7 +4,7 @@ Disable sharing of a compute limit by the host subscription with its guest subsc
 
 ## Versions
 
-### [2025-08-15](/Resources/mgmt-plane/L3N1YnNjcmlwdGlvbnMve30vcHJvdmlkZXJzL21pY3Jvc29mdC5jb21wdXRlbGltaXQvbG9jYXRpb25zL3t9L3NoYXJlZGxpbWl0cy97fQ==/2025-08-15.xml) **Preview**
+### [2025-08-15](/Resources/mgmt-plane/L3N1YnNjcmlwdGlvbnMve30vcHJvdmlkZXJzL21pY3Jvc29mdC5jb21wdXRlbGltaXQvbG9jYXRpb25zL3t9L3NoYXJlZGxpbWl0cy97fQ==/2025-08-15.xml) **Stable**
 
 <!-- mgmt-plane /subscriptions/{}/providers/microsoft.computelimit/locations/{}/sharedlimits/{} 2025-08-15 -->
 

--- a/Commands/computelimit/shared-limit/_show.md
+++ b/Commands/computelimit/shared-limit/_show.md
@@ -4,7 +4,7 @@ Get a compute limit shared by the host subscription with its guest subscriptions
 
 ## Versions
 
-### [2025-08-15](/Resources/mgmt-plane/L3N1YnNjcmlwdGlvbnMve30vcHJvdmlkZXJzL21pY3Jvc29mdC5jb21wdXRlbGltaXQvbG9jYXRpb25zL3t9L3NoYXJlZGxpbWl0cy97fQ==/2025-08-15.xml) **Preview**
+### [2025-08-15](/Resources/mgmt-plane/L3N1YnNjcmlwdGlvbnMve30vcHJvdmlkZXJzL21pY3Jvc29mdC5jb21wdXRlbGltaXQvbG9jYXRpb25zL3t9L3NoYXJlZGxpbWl0cy97fQ==/2025-08-15.xml) **Stable**
 
 <!-- mgmt-plane /subscriptions/{}/providers/microsoft.computelimit/locations/{}/sharedlimits/{} 2025-08-15 -->
 


### PR DESCRIPTION
 Promotes the 8 computelimit command .md files from **Preview** to **Stable** to match Azure/azure-cli-extensions PR #9788 (computelimit extension 1.0.0). API version 2025-08-15 (lives under stable/ in azure-rest-api-specs).
 
 Related: Azure/azure-cli-extensions#9788