### PR TITLE
[App Service] Remove preview flag from managed instance `az appservice plan` commands

### DIFF
--- a/Commands/appservice/plan/managed-instance/_show-rdp-password.md
+++ b/Commands/appservice/plan/managed-instance/_show-rdp-password.md
@@ -4,6 +4,6 @@ Get the RDP password for an IsCustomMode ServerFarm.
 
 ## Versions
 
-### [2025-03-01](/Resources/mgmt-plane/L3N1YnNjcmlwdGlvbnMve30vcmVzb3VyY2Vncm91cHMve30vcHJvdmlkZXJzL21pY3Jvc29mdC53ZWIvc2VydmVyZmFybXMve30vZ2V0cmRwcGFzc3dvcmQ=/2025-03-01.xml) **Preview**
+### [2025-03-01](/Resources/mgmt-plane/L3N1YnNjcmlwdGlvbnMve30vcmVzb3VyY2Vncm91cHMve30vcHJvdmlkZXJzL21pY3Jvc29mdC53ZWIvc2VydmVyZmFybXMve30vZ2V0cmRwcGFzc3dvcmQ=/2025-03-01.xml) **Stable**
 
 <!-- mgmt-plane /subscriptions/{}/resourcegroups/{}/providers/microsoft.web/serverfarms/{}/getrdppassword 2025-03-01 -->

--- a/Commands/appservice/plan/managed-instance/instance/_list.md
+++ b/Commands/appservice/plan/managed-instance/instance/_list.md
@@ -4,7 +4,7 @@ List instances for a managed instance App Service plan.
 
 ## Versions
 
-### [2025-03-01](/Resources/mgmt-plane/L3N1YnNjcmlwdGlvbnMve30vcmVzb3VyY2Vncm91cHMve30vcHJvdmlkZXJzL21pY3Jvc29mdC53ZWIvc2VydmVyZmFybXMve30vbGlzdGluc3RhbmNlcw==/2025-03-01.xml) **Preview**
+### [2025-03-01](/Resources/mgmt-plane/L3N1YnNjcmlwdGlvbnMve30vcmVzb3VyY2Vncm91cHMve30vcHJvdmlkZXJzL21pY3Jvc29mdC53ZWIvc2VydmVyZmFybXMve30vbGlzdGluc3RhbmNlcw==/2025-03-01.xml) **Stable**
 
 <!-- mgmt-plane /subscriptions/{}/resourcegroups/{}/providers/microsoft.web/serverfarms/{}/listinstances 2025-03-01 -->
 

--- a/Commands/appservice/plan/managed-instance/instance/_recycle.md
+++ b/Commands/appservice/plan/managed-instance/instance/_recycle.md
@@ -4,7 +4,7 @@ Recycle a specific instance in a managed instance App Service plan.
 
 ## Versions
 
-### [2025-03-01](/Resources/mgmt-plane/L3N1YnNjcmlwdGlvbnMve30vcmVzb3VyY2Vncm91cHMve30vcHJvdmlkZXJzL21pY3Jvc29mdC53ZWIvc2VydmVyZmFybXMve30vd29ya2Vycy97fS9yZWN5Y2xlaW5zdGFuY2U=/2025-03-01.xml) **Preview**
+### [2025-03-01](/Resources/mgmt-plane/L3N1YnNjcmlwdGlvbnMve30vcmVzb3VyY2Vncm91cHMve30vcHJvdmlkZXJzL21pY3Jvc29mdC53ZWIvc2VydmVyZmFybXMve30vd29ya2Vycy97fS9yZWN5Y2xlaW5zdGFuY2U=/2025-03-01.xml) **Stable**
 
 <!-- mgmt-plane /subscriptions/{}/resourcegroups/{}/providers/microsoft.web/serverfarms/{}/workers/{}/recycleinstance 2025-03-01 -->
 


### PR DESCRIPTION
Removes the preview flag (Preview -> Stable) from the managed instance commands, corresponding to https://github.com/Azure/azure-cli/pull/33690