### PR TITLE
fix(identity): correctly reference identity commands so exports work

### DIFF
--- a/Commands/readme.md
+++ b/Commands/readme.md
@@ -200,6 +200,9 @@
 - [healthcareapis](/Commands/healthcareapis/readme.md)
 : Azure Healthcare APIs is a secure cloud platform for managing health data, supporting analytics, machine learning, and scalable solutions.
 
+- [identity](/Commands/identity/readme.md)
+: Manage Managed Identity
+
 - [image](/Commands/image/readme.md)
 : Manage custom virtual machine images.
 


### PR DESCRIPTION
When attempting to use the `aaz-dev` [workflow tooling](https://azure.github.io/aaz-dev-tools/), I'm unable to export my azure-cli command_module.  The flask app shows the below error.

```
[2026-07-14 18:08:27,814] ERROR in app: InvalidAPIUsage:
{
  "message": "Command not exist: identity create"
}
ERROR:aaz_dev.app.app:InvalidAPIUsage:
{
  "message": "Command not exist: identity create"
}
```

Adding the commands for `identity` to the `readme.md` below fixes the export issues.  