### PR TITLE
network application-gateway: register API versions 2024-10-01 → 2025-07-01 in tree.json

### DIFF
--- a/Commands/tree.json
+++ b/Commands/tree.json
@@ -121453,6 +121453,46 @@
                         "version": "2023-11-01"
                       }
                     ]
+                  },
+                  {
+                    "name": "2024-10-01",
+                    "resources": [
+                      {
+                        "id": "/subscriptions/{}/resourcegroups/{}/providers/microsoft.network/applicationgateways/{}",
+                        "plane": "mgmt-plane",
+                        "version": "2024-10-01"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "2025-01-01",
+                    "resources": [
+                      {
+                        "id": "/subscriptions/{}/resourcegroups/{}/providers/microsoft.network/applicationgateways/{}",
+                        "plane": "mgmt-plane",
+                        "version": "2025-01-01"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "2025-05-01",
+                    "resources": [
+                      {
+                        "id": "/subscriptions/{}/resourcegroups/{}/providers/microsoft.network/applicationgateways/{}",
+                        "plane": "mgmt-plane",
+                        "version": "2025-05-01"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "2025-07-01",
+                    "resources": [
+                      {
+                        "id": "/subscriptions/{}/resourcegroups/{}/providers/microsoft.network/applicationgateways/{}",
+                        "plane": "mgmt-plane",
+                        "version": "2025-07-01"
+                      }
+                    ]
                   }
                 ]
               },
@@ -121986,6 +122026,70 @@
                         "version": "2023-11-01"
                       }
                     ]
+                  },
+                  {
+                    "name": "2024-10-01",
+                    "resources": [
+                      {
+                        "id": "/subscriptions/{}/resourcegroups/{}/providers/microsoft.network/applicationgateways/{}",
+                        "plane": "mgmt-plane",
+                        "version": "2024-10-01"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "2025-01-01",
+                    "resources": [
+                      {
+                        "id": "/subscriptions/{}/resourcegroups/{}/providers/microsoft.network/applicationgateways/{}",
+                        "plane": "mgmt-plane",
+                        "version": "2025-01-01"
+                      }
+                    ],
+                    "examples": [
+                      {
+                        "commands": [
+                          "network application-gateway show -g MyResourceGroup -n MyAppGateway"
+                        ],
+                        "name": "Get the details of an application gateway."
+                      }
+                    ]
+                  },
+                  {
+                    "name": "2025-05-01",
+                    "resources": [
+                      {
+                        "id": "/subscriptions/{}/resourcegroups/{}/providers/microsoft.network/applicationgateways/{}",
+                        "plane": "mgmt-plane",
+                        "version": "2025-05-01"
+                      }
+                    ],
+                    "examples": [
+                      {
+                        "commands": [
+                          "network application-gateway show -g MyResourceGroup -n MyAppGateway"
+                        ],
+                        "name": "Get the details of an application gateway."
+                      }
+                    ]
+                  },
+                  {
+                    "name": "2025-07-01",
+                    "resources": [
+                      {
+                        "id": "/subscriptions/{}/resourcegroups/{}/providers/microsoft.network/applicationgateways/{}",
+                        "plane": "mgmt-plane",
+                        "version": "2025-07-01"
+                      }
+                    ],
+                    "examples": [
+                      {
+                        "commands": [
+                          "network application-gateway show -g MyResourceGroup -n MyAppGateway"
+                        ],
+                        "name": "Get the details of an application gateway."
+                      }
+                    ]
                   }
                 ]
               },
@@ -122260,6 +122364,88 @@
                         "id": "/subscriptions/{}/resourcegroups/{}/providers/microsoft.network/applicationgateways/{}",
                         "plane": "mgmt-plane",
                         "version": "2023-11-01"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "2024-10-01",
+                    "resources": [
+                      {
+                        "id": "/subscriptions/{}/resourcegroups/{}/providers/microsoft.network/applicationgateways/{}",
+                        "plane": "mgmt-plane",
+                        "version": "2024-10-01"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "2025-01-01",
+                    "resources": [
+                      {
+                        "id": "/subscriptions/{}/resourcegroups/{}/providers/microsoft.network/applicationgateways/{}",
+                        "plane": "mgmt-plane",
+                        "version": "2025-01-01"
+                      }
+                    ],
+                    "examples": [
+                      {
+                        "commands": [
+                          "network application-gateway update --name MyApplicationGateway --resource-group MyResourceGroup --set sku.tier=WAF_v2"
+                        ],
+                        "name": "Update an application gateway."
+                      },
+                      {
+                        "commands": [
+                          "network application-gateway update -n MyApplicationGateway --ssl-profiles [0].client-auth-configuration.verify-client-revocation=OCSP"
+                        ],
+                        "name": "Enable client cert revocation via OCSP."
+                      }
+                    ]
+                  },
+                  {
+                    "name": "2025-05-01",
+                    "resources": [
+                      {
+                        "id": "/subscriptions/{}/resourcegroups/{}/providers/microsoft.network/applicationgateways/{}",
+                        "plane": "mgmt-plane",
+                        "version": "2025-05-01"
+                      }
+                    ],
+                    "examples": [
+                      {
+                        "commands": [
+                          "network application-gateway update --name MyApplicationGateway --resource-group MyResourceGroup --set sku.tier=WAF_v2"
+                        ],
+                        "name": "Update an application gateway."
+                      },
+                      {
+                        "commands": [
+                          "network application-gateway update -n MyApplicationGateway --ssl-profiles [0].client-auth-configuration.verify-client-revocation=OCSP"
+                        ],
+                        "name": "Enable client cert revocation via OCSP."
+                      }
+                    ]
+                  },
+                  {
+                    "name": "2025-07-01",
+                    "resources": [
+                      {
+                        "id": "/subscriptions/{}/resourcegroups/{}/providers/microsoft.network/applicationgateways/{}",
+                        "plane": "mgmt-plane",
+                        "version": "2025-07-01"
+                      }
+                    ],
+                    "examples": [
+                      {
+                        "commands": [
+                          "network application-gateway update --name MyApplicationGateway --resource-group MyResourceGroup --set sku.tier=WAF_v2"
+                        ],
+                        "name": "Update an application gateway."
+                      },
+                      {
+                        "commands": [
+                          "network application-gateway update -n MyApplicationGateway --ssl-profiles [0].client-auth-configuration.verify-client-revocation=OCSP"
+                        ],
+                        "name": "Enable client cert revocation via OCSP."
                       }
                     ]
                   }
@@ -139241,7 +139427,7 @@
                             "examples": [
                               {
                                 "commands": [
-                                  "network manager verifier-workspace reachability-analysis-intent create --name \"myAnalysisIntent” --workspace-name \"myVerifierWorkspace\" --network-manager-name \"myAVNM\" --resource-group \"myAVNMResourceGroup\" --subscription \"00000000-0000-0000-0000-000000000000\" --description “hello world intent” --source-resource-id “/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/testVmSrc” --destination-resource-id “/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/testVmDest” --ip-traffic \"{source-ips:[\"10.0.0.0/16”, “12.0.0.0”],destination-ips:[\"12.0.0.0/8”, “10.0.0.0”],source-ports:[\"20”, “23”],destination-ports:[\"80”, “81”],protocols:[\"TCP”, “UDP”]}\""
+                                  "network manager verifier-workspace reachability-analysis-intent create --name \"myAnalysisIntent\u201d --workspace-name \"myVerifierWorkspace\" --network-manager-name \"myAVNM\" --resource-group \"myAVNMResourceGroup\" --subscription \"00000000-0000-0000-0000-000000000000\" --description \u201chello world intent\u201d --source-resource-id \u201c/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/testVmSrc\u201d --destination-resource-id \u201c/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/testVmDest\u201d --ip-traffic \"{source-ips:[\"10.0.0.0/16\u201d, \u201c12.0.0.0\u201d],destination-ips:[\"12.0.0.0/8\u201d, \u201c10.0.0.0\u201d],source-ports:[\"20\u201d, \u201c23\u201d],destination-ports:[\"80\u201d, \u201c81\u201d],protocols:[\"TCP\u201d, \u201cUDP\u201d]}\""
                                 ],
                                 "name": "ReachabilityAnalysisIntentCreate"
                               }
@@ -139260,7 +139446,7 @@
                             "examples": [
                               {
                                 "commands": [
-                                  "network manager verifier-workspace reachability-analysis-intent create --name \"myAnalysisIntent” --workspace-name \"myVerifierWorkspace\" --network-manager-name \"myAVNM\" --resource-group \"myAVNMResourceGroup\" --subscription \"00000000-0000-0000-0000-000000000000\" --description “hello world intent” --source-resource-id “/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/testVmSrc” --destination-resource-id “/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/testVmDest” --ip-traffic \"{source-ips:[\"10.0.0.0/16”, “12.0.0.0”],destination-ips:[\"12.0.0.0/8”, “10.0.0.0”],source-ports:[\"20”, “23”],destination-ports:[\"80”, “81”],protocols:[\"TCP”, “UDP”]}\""
+                                  "network manager verifier-workspace reachability-analysis-intent create --name \"myAnalysisIntent\u201d --workspace-name \"myVerifierWorkspace\" --network-manager-name \"myAVNM\" --resource-group \"myAVNMResourceGroup\" --subscription \"00000000-0000-0000-0000-000000000000\" --description \u201chello world intent\u201d --source-resource-id \u201c/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/testVmSrc\u201d --destination-resource-id \u201c/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/testVmDest\u201d --ip-traffic \"{source-ips:[\"10.0.0.0/16\u201d, \u201c12.0.0.0\u201d],destination-ips:[\"12.0.0.0/8\u201d, \u201c10.0.0.0\u201d],source-ports:[\"20\u201d, \u201c23\u201d],destination-ports:[\"80\u201d, \u201c81\u201d],protocols:[\"TCP\u201d, \u201cUDP\u201d]}\""
                                 ],
                                 "name": "ReachabilityAnalysisIntentCreate"
                               }
@@ -139292,7 +139478,7 @@
                             "examples": [
                               {
                                 "commands": [
-                                  "network manager verifier-workspace reachability-analysis-intent delete --name “myAnalysisIntent” --workspace-name \"myVerifierWorkspace\" --network-manager-name \"myAVNM\" --resource-group \"myAVNMResourceGroup\" --subscription \"00000000-0000-0000-0000-000000000000\""
+                                  "network manager verifier-workspace reachability-analysis-intent delete --name \u201cmyAnalysisIntent\u201d --workspace-name \"myVerifierWorkspace\" --network-manager-name \"myAVNM\" --resource-group \"myAVNMResourceGroup\" --subscription \"00000000-0000-0000-0000-000000000000\""
                                 ],
                                 "name": "ReachabilityAnalysisIntentDelete"
                               }
@@ -139311,7 +139497,7 @@
                             "examples": [
                               {
                                 "commands": [
-                                  "network manager verifier-workspace reachability-analysis-intent delete --name “myAnalysisIntent” --workspace-name \"myVerifierWorkspace\" --network-manager-name \"myAVNM\" --resource-group \"myAVNMResourceGroup\" --subscription \"00000000-0000-0000-0000-000000000000\""
+                                  "network manager verifier-workspace reachability-analysis-intent delete --name \u201cmyAnalysisIntent\u201d --workspace-name \"myVerifierWorkspace\" --network-manager-name \"myAVNM\" --resource-group \"myAVNMResourceGroup\" --subscription \"00000000-0000-0000-0000-000000000000\""
                                 ],
                                 "name": "ReachabilityAnalysisIntentDelete"
                               }
@@ -139445,7 +139631,7 @@
                             "examples": [
                               {
                                 "commands": [
-                                  "network manager verifier-workspace reachability-analysis-intent update --name \"myAnalysisIntent \" --workspace-name \"myVerifierWorkspace\" --network-manager-name \"myAVNM\" --resource-group \"myAVNMResourceGroup\" --subscription \"00000000-0000-0000-0000-000000000000\" --description “updated description”"
+                                  "network manager verifier-workspace reachability-analysis-intent update --name \"myAnalysisIntent \" --workspace-name \"myVerifierWorkspace\" --network-manager-name \"myAVNM\" --resource-group \"myAVNMResourceGroup\" --subscription \"00000000-0000-0000-0000-000000000000\" --description \u201cupdated description\u201d"
                                 ],
                                 "name": "ReachabilityAnalysisIntentUpdate"
                               }
@@ -139464,7 +139650,7 @@
                             "examples": [
                               {
                                 "commands": [
-                                  "network manager verifier-workspace reachability-analysis-intent update --name \"myAnalysisIntent \" --workspace-name \"myVerifierWorkspace\" --network-manager-name \"myAVNM\" --resource-group \"myAVNMResourceGroup\" --subscription \"00000000-0000-0000-0000-000000000000\" --description “updated description”"
+                                  "network manager verifier-workspace reachability-analysis-intent update --name \"myAnalysisIntent \" --workspace-name \"myVerifierWorkspace\" --network-manager-name \"myAVNM\" --resource-group \"myAVNMResourceGroup\" --subscription \"00000000-0000-0000-0000-000000000000\" --description \u201cupdated description\u201d"
                                 ],
                                 "name": "ReachabilityAnalysisIntentUpdate"
                               }
@@ -139509,7 +139695,7 @@
                             "examples": [
                               {
                                 "commands": [
-                                  "network manager verifier-workspace reachability-analysis-run create --name \"myAnalysisRun\" --workspace-name \"myVerifierWorkspace\" --network-manager-name \"myAVNM\" --resource-group \"myAVNMResourceGroup\" --subscription \"00000000-0000-0000-0000-000000000000\" --description “hello world analysis run” --intent-id “/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ myAVNMResourceGroup /providers/Microsoft.Network/networkManagers/myAVNM/verifierWorkspaces/myVerifierWorkspace /reachabilityAnalysisIntents/myAnalysisIntent”"
+                                  "network manager verifier-workspace reachability-analysis-run create --name \"myAnalysisRun\" --workspace-name \"myVerifierWorkspace\" --network-manager-name \"myAVNM\" --resource-group \"myAVNMResourceGroup\" --subscription \"00000000-0000-0000-0000-000000000000\" --description \u201chello world analysis run\u201d --intent-id \u201c/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ myAVNMResourceGroup /providers/Microsoft.Network/networkManagers/myAVNM/verifierWorkspaces/myVerifierWorkspace /reachabilityAnalysisIntents/myAnalysisIntent\u201d"
                                 ],
                                 "name": "ReachabilityAnalysisRunCreate"
                               }
@@ -139528,7 +139714,7 @@
                             "examples": [
                               {
                                 "commands": [
-                                  "network manager verifier-workspace reachability-analysis-run create --name \"myAnalysisRun\" --workspace-name \"myVerifierWorkspace\" --network-manager-name \"myAVNM\" --resource-group \"myAVNMResourceGroup\" --subscription \"00000000-0000-0000-0000-000000000000\" --description “hello world analysis run” --intent-id “/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ myAVNMResourceGroup /providers/Microsoft.Network/networkManagers/myAVNM/verifierWorkspaces/myVerifierWorkspace /reachabilityAnalysisIntents/myAnalysisIntent”"
+                                  "network manager verifier-workspace reachability-analysis-run create --name \"myAnalysisRun\" --workspace-name \"myVerifierWorkspace\" --network-manager-name \"myAVNM\" --resource-group \"myAVNMResourceGroup\" --subscription \"00000000-0000-0000-0000-000000000000\" --description \u201chello world analysis run\u201d --intent-id \u201c/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ myAVNMResourceGroup /providers/Microsoft.Network/networkManagers/myAVNM/verifierWorkspaces/myVerifierWorkspace /reachabilityAnalysisIntents/myAnalysisIntent\u201d"
                                 ],
                                 "name": "ReachabilityAnalysisRunCreate"
                               }
@@ -139560,7 +139746,7 @@
                             "examples": [
                               {
                                 "commands": [
-                                  "network manager verifier-workspace reachability-analysis-run delete --workspace-name \"myVerifierWorkspace\" --network-manager-name \"myAVNM\" --resource-group \"myAVNMResourceGroup\" --name “myAnalysisRun” --subscription \"00000000-0000-0000-0000-000000000000\""
+                                  "network manager verifier-workspace reachability-analysis-run delete --workspace-name \"myVerifierWorkspace\" --network-manager-name \"myAVNM\" --resource-group \"myAVNMResourceGroup\" --name \u201cmyAnalysisRun\u201d --subscription \"00000000-0000-0000-0000-000000000000\""
                                 ],
                                 "name": "ReachabilityAnalysisRunDelete"
                               }
@@ -139579,7 +139765,7 @@
                             "examples": [
                               {
                                 "commands": [
-                                  "network manager verifier-workspace reachability-analysis-run delete --workspace-name \"myVerifierWorkspace\" --network-manager-name \"myAVNM\" --resource-group \"myAVNMResourceGroup\" --name “myAnalysisRun” --subscription \"00000000-0000-0000-0000-000000000000\""
+                                  "network manager verifier-workspace reachability-analysis-run delete --workspace-name \"myVerifierWorkspace\" --network-manager-name \"myAVNM\" --resource-group \"myAVNMResourceGroup\" --name \u201cmyAnalysisRun\u201d --subscription \"00000000-0000-0000-0000-000000000000\""
                                 ],
                                 "name": "ReachabilityAnalysisRunDelete"
                               }
@@ -139760,7 +139946,7 @@
                         "examples": [
                           {
                             "commands": [
-                              "network manager verifier-workspace create --name \"myVerifierWorkspace\" --network-manager-name \"myAVNM\" --resource-group \"myAVNMResourceGroup\" --subscription \"00000000-0000-0000-0000-000000000000\" --description “hello world workspace” --tags [“color”: “blue”] --location \"eastus\""
+                              "network manager verifier-workspace create --name \"myVerifierWorkspace\" --network-manager-name \"myAVNM\" --resource-group \"myAVNMResourceGroup\" --subscription \"00000000-0000-0000-0000-000000000000\" --description \u201chello world workspace\u201d --tags [\u201ccolor\u201d: \u201cblue\u201d] --location \"eastus\""
                             ],
                             "name": "VerifierWorkspaceCreate"
                           }
@@ -139779,7 +139965,7 @@
                         "examples": [
                           {
                             "commands": [
-                              "network manager verifier-workspace create --name \"myVerifierWorkspace\" --network-manager-name \"myAVNM\" --resource-group \"myAVNMResourceGroup\" --subscription \"00000000-0000-0000-0000-000000000000\" --description “hello world workspace” --tags [“color”: “blue”] --location \"eastus\""
+                              "network manager verifier-workspace create --name \"myVerifierWorkspace\" --network-manager-name \"myAVNM\" --resource-group \"myAVNMResourceGroup\" --subscription \"00000000-0000-0000-0000-000000000000\" --description \u201chello world workspace\u201d --tags [\u201ccolor\u201d: \u201cblue\u201d] --location \"eastus\""
                             ],
                             "name": "VerifierWorkspaceCreate"
                           }
@@ -139960,7 +140146,7 @@
                         "examples": [
                           {
                             "commands": [
-                              "network manager verifier-workspace update --name \"myVerifierWorkspace\" --network-manager-name \"myAVNM\" --resource-group \"myAVNMResourceGroup\" --subscription \"00000000-0000-0000-0000-000000000000\" --description “hello world workspace”"
+                              "network manager verifier-workspace update --name \"myVerifierWorkspace\" --network-manager-name \"myAVNM\" --resource-group \"myAVNMResourceGroup\" --subscription \"00000000-0000-0000-0000-000000000000\" --description \u201chello world workspace\u201d"
                             ],
                             "name": "VerifierWorkspaceUpdate"
                           }
@@ -139979,7 +140165,7 @@
                         "examples": [
                           {
                             "commands": [
-                              "network manager verifier-workspace update --name \"myVerifierWorkspace\" --network-manager-name \"myAVNM\" --resource-group \"myAVNMResourceGroup\" --subscription \"00000000-0000-0000-0000-000000000000\" --description “hello world workspace”"
+                              "network manager verifier-workspace update --name \"myVerifierWorkspace\" --network-manager-name \"myAVNM\" --resource-group \"myAVNMResourceGroup\" --subscription \"00000000-0000-0000-0000-000000000000\" --description \u201chello world workspace\u201d"
                             ],
                             "name": "VerifierWorkspaceUpdate"
                           }
@@ -192845,7 +193031,7 @@
                   },
                   "decline": {
                     "help": {
-                      "short": "Declines a machine that is pending approval during registration. This effectively “dead ends” this machine and is an explicit refusal to let the machine proceed with further provisioning."
+                      "short": "Declines a machine that is pending approval during registration. This effectively \u201cdead ends\u201d this machine and is an explicit refusal to let the machine proceed with further provisioning."
                     },
                     "names": [
                       "networkcloud",
@@ -232412,7 +232598,7 @@
               },
               "update": {
                 "help": {
-                  "short": "Update the specific troubleshooter action under a resource or subscription using the ‘solutionId’ and  ‘properties.parameters’ as the trigger. <br/> Azure Troubleshooters help with hard to classify issues, reducing the gap between customer observed problems and solutions by guiding the user effortlessly through the troubleshooting process. Each Troubleshooter flow represents a problem area within Azure and has a complex tree-like structure that addresses many root causes. These flows are prepared with the help of Subject Matter experts and customer support engineers by carefully considering previous support requests raised by customers. Troubleshooters terminate at a well curated solution based off of resource backend signals and customer manual selections."
+                  "short": "Update the specific troubleshooter action under a resource or subscription using the \u2018solutionId\u2019 and  \u2018properties.parameters\u2019 as the trigger. <br/> Azure Troubleshooters help with hard to classify issues, reducing the gap between customer observed problems and solutions by guiding the user effortlessly through the troubleshooting process. Each Troubleshooter flow represents a problem area within Azure and has a complex tree-like structure that addresses many root causes. These flows are prepared with the help of Subject Matter experts and customer support engineers by carefully considering previous support requests raised by customers. Troubleshooters terminate at a well curated solution based off of resource backend signals and customer manual selections."
                 },
                 "names": [
                   "self-help",


### PR DESCRIPTION
## Description

Durable AAZ command-model source for issue `#33981`.

please provide the link to the corresponding pull request in [Azure/azure-cli](https://github.com/Azure/azure-cli) or [Azure/azure-cli-extensions](https://github.com/Azure/azure-cli-extensions):

https://github.com/a0x1ab/azure-cli/pull/7

`network application-gateway show/create/update` were missing versions `2024-10-01`–`2025-07-01` from `Commands/tree.json`, so the code generator targeted an older schema that silently dropped the Managed-HSM SSL-certificate fields (`sslCertificates[].properties.hsm.keyId` / `publicCertData`) introduced in the `2025-07-01` ARM API spec.

- **`Commands/tree.json`**: Added version entries `2024-10-01`, `2025-01-01`, `2025-05-01`, `2025-07-01` for `network application-gateway show`, `create`, and `update`. No changes to the XML/JSON resource files — `Resources/…/2025-07-01.xml` and `2025-07-01.json` already carry the full `hsm` schema.