### PR TITLE
NetworkCloud v5.1.1 update to remove 'create' and 'delete' from 'kubernetesversion' command group for non-support.

### DIFF
--- a/Commands/networkcloud/kubernetesversion/_update.md
+++ b/Commands/networkcloud/kubernetesversion/_update.md
@@ -34,5 +34,5 @@ Update tags associated with the Kubernetes version resource. No other properties
 
 - Patch a kubernetes version resource.
     ```bash
-        networkcloud kubernetesversion create --resource-group resourceGroupName --kubernetes-version-name default --tags "{key1:myvalue1,key2:myvalue2}"
+        networkcloud kubernetesversion update --resource-group resourceGroupName --kubernetes-version-name default --tags "{key1:myvalue1,key2:myvalue2}"
     ```


### PR DESCRIPTION
NetworkCloud v5.1.1 update to remove 'create' and 'delete' from 'kubernetesversion' command group for non-support.

azure-cli-extensions: https://github.com/Azure/azure-cli-extensions/pull/10289
